### PR TITLE
Update Google.Protobuf from 3.14.0 to 3.15.0

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,20 +1,20 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="BouncyCastle" version="1.8.5" targetFramework="net472" />
-  <package id="EntityFramework" version="6.3.0" targetFramework="net472" />
-  <package id="Google.Protobuf" version="3.14.0" targetFramework="net472" />
-  <package id="K4os.Compression.LZ4" version="1.2.6" targetFramework="net472" />
-  <package id="K4os.Compression.LZ4.Streams" version="1.2.6" targetFramework="net472" />
-  <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net472" />
-  <package id="MySql.Data" version="8.0.27" targetFramework="net472" />
-  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472" />
-  <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net472" />
-  <package id="System.Buffers" version="4.5.1" targetFramework="net472" />
-  <package id="System.Data.SQLite" version="1.0.113.1" targetFramework="net472" />
-  <package id="System.Data.SQLite.Core" version="1.0.113.1" targetFramework="net472" />
-  <package id="System.Data.SQLite.EF6" version="1.0.113.0" targetFramework="net472" />
-  <package id="System.Data.SQLite.Linq" version="1.0.113.0" targetFramework="net472" />
-  <package id="System.Memory" version="4.5.4" targetFramework="net472" />
-  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472" />
-  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net472" />
+  <package id="BouncyCastle" version="1.8.5" targetFramework="net472"/>
+  <package id="EntityFramework" version="6.3.0" targetFramework="net472"/>
+  <package id="Google.Protobuf" version="3.15.0" targetFramework="net472"/>
+  <package id="K4os.Compression.LZ4" version="1.2.6" targetFramework="net472"/>
+  <package id="K4os.Compression.LZ4.Streams" version="1.2.6" targetFramework="net472"/>
+  <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net472"/>
+  <package id="MySql.Data" version="8.0.27" targetFramework="net472"/>
+  <package id="Newtonsoft.Json" version="12.0.3" targetFramework="net472"/>
+  <package id="Selenium.WebDriver" version="3.141.0" targetFramework="net472"/>
+  <package id="System.Buffers" version="4.5.1" targetFramework="net472"/>
+  <package id="System.Data.SQLite" version="1.0.113.1" targetFramework="net472"/>
+  <package id="System.Data.SQLite.Core" version="1.0.113.1" targetFramework="net472"/>
+  <package id="System.Data.SQLite.EF6" version="1.0.113.0" targetFramework="net472"/>
+  <package id="System.Data.SQLite.Linq" version="1.0.113.0" targetFramework="net472"/>
+  <package id="System.Memory" version="4.5.4" targetFramework="net472"/>
+  <package id="System.Numerics.Vectors" version="4.5.0" targetFramework="net472"/>
+  <package id="System.Runtime.CompilerServices.Unsafe" version="5.0.0" targetFramework="net472"/>
 </packages>


### PR DESCRIPTION
This PR was generated by CodeThreat utilizing authenticated user credentials.

  ## Issue Description

  ### "Nullptr dereference when a null char is present in a proto symbol. The symbol is parsed incorrectly, leading to an unchecked call into the pr
  
  ### Changes included in this PR
  
  - Modifications to the following files to address the vulnerabilities with updated dependencies:
    - packages.config
  
  ### Security Issues Addressed
  
  #### Through Dependency Upgrades:
  
  | Issue | Upgrade | Severity |
  | --- | --- | --- |
  | protobuf: Incorrect parsing of nullchar in the proto symbol  | Google.Protobuf: 3.14.0 -> 3.15.0 | HIGH |
  
  Review the modifications in this PR to confirm they do not introduce any issues to your project.
  