### PR TITLE
Update Google.Protobuf from 3.14.0 to 3.15.0

### DIFF
--- a/packages.config
+++ b/packages.config
@@ -1,8 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="BouncyCastle" version="1.8.5" targetFramework="net472" />
   <package id="EntityFramework" version="6.3.0" targetFramework="net472" />
-  <package id="Google.Protobuf" version="3.14.0" targetFramework="net472" />
+  <package id="Google.Protobuf" version="3.15.0" targetFramework="net472" />
   <package id="K4os.Compression.LZ4" version="1.2.6" targetFramework="net472" />
   <package id="K4os.Compression.LZ4.Streams" version="1.2.6" targetFramework="net472" />
   <package id="K4os.Hash.xxHash" version="1.0.6" targetFramework="net472" />


### PR DESCRIPTION
This PR was generated by CodeThreat utilizing authenticated user credentials.

  ## Issue Description

  ### "Nullptr dereference when a null char is present in a proto symbol. The symbol is parsed incorrectly, leading to an unchecked call into the pr
  
  ### Changes included in this PR
  
  - Modifications to the following files to address the vulnerabilities with updated dependencies:
    - packages.config
  
  ### Security Issues Addressed
  
  #### Through Dependency Upgrades:
  
  | Issue | Upgrade | Severity |
  | --- | --- | --- |
  | protobuf: Incorrect parsing of nullchar in the proto symbol  | Google.Protobuf: 3.14.0 -> 3.15.0 | HIGH |
  
  Review the modifications in this PR to confirm they do not introduce any issues to your project.
  